### PR TITLE
Removed Depreciations

### DIFF
--- a/lib/Screens/CountryReportPage.dart
+++ b/lib/Screens/CountryReportPage.dart
@@ -34,7 +34,7 @@ class _CountryReportPageState extends State<CountryReportPage> {
       appBar: AppBar(
         title: Text(
           '${_countryReport.countryName}',
-          style: Theme.of(context).textTheme.title,
+          style: Theme.of(context).textTheme.headline6,
         ),
         backgroundColor: Colors.white,
         elevation: 0.0,

--- a/lib/Screens/homePage.dart
+++ b/lib/Screens/homePage.dart
@@ -60,8 +60,6 @@ class _HomePageState extends State<HomePage> {
                             Text(
                               "Requirements",
                               style: Theme.of(context).textTheme.headline6,
-                              "Requirements",
-                              style: Theme.of(context).textTheme.title,
                             ),
                             SizedBox(
                               height: 8.0,

--- a/lib/Screens/homePage.dart
+++ b/lib/Screens/homePage.dart
@@ -31,7 +31,7 @@ class _HomePageState extends State<HomePage> {
                           children: <Widget>[
                             Text(
                               'Prevent COVID - 19 ',
-                              style: Theme.of(context).textTheme.title.copyWith(
+                              style: Theme.of(context).textTheme.headline6.copyWith(
                                   color: Colors.white,
                                   fontWeight: FontWeight.w100),
                             ),
@@ -58,7 +58,7 @@ class _HomePageState extends State<HomePage> {
                           children: <Widget>[
                             Text(
                               "Requirments",
-                              style: Theme.of(context).textTheme.title,
+                              style: Theme.of(context).textTheme.headline6,
                             ),
                             SizedBox(
                               height: 8.0,
@@ -81,7 +81,7 @@ class _HomePageState extends State<HomePage> {
                           children: <Widget>[
                             Text(
                               'News',
-                              style: Theme.of(context).textTheme.title,
+                              style: Theme.of(context).textTheme.headline6,
                             ),
                             SizedBox(
                               height: 24.0,

--- a/lib/Screens/preventionPage.dart
+++ b/lib/Screens/preventionPage.dart
@@ -38,7 +38,7 @@ class _PreventioPageState extends State<PreventioPage> {
                         TextSpan(
                           text:
                               "Stay aware of the latest information on the COVID-19 outbreak, available on the WHO website and through your national and local public health authority. Many countries around the world have seen cases of COVID-19 and several have seen outbreaks. Authorities in China and some other countries have succeeded in slowing or stopping their outbreaks. However, the situation is unpredictable so check regularly for the latest news.",
-                          style: Theme.of(context).textTheme.subhead,
+                          style: Theme.of(context).textTheme.subtitle1,
                         ),
                       ],
                     ),

--- a/lib/Screens/reportPage.dart
+++ b/lib/Screens/reportPage.dart
@@ -33,7 +33,7 @@ class _ReportPageState extends State<ReportPage> {
       appBar: AppBar(
         title: Text(
           'Reports',
-          style: Theme.of(context).textTheme.title,
+          style: Theme.of(context).textTheme.headline6,
         ),
         backgroundColor: Colors.white,
         elevation: 0.0,

--- a/lib/Screens/symptomsPage.dart
+++ b/lib/Screens/symptomsPage.dart
@@ -35,7 +35,7 @@ class SymptomsPage extends StatelessWidget {
                               "The most common symptoms of COVID-19 are fever, tiredness, and dry cough. Some patients may have aches and pains, nasal congestion, runny nose, sore throat or diarrhea. These symptoms are usually mild and begin gradually. Some people become infected but don’t develop any symptoms and don't feel unwell. Most people (about 80%) recover from the disease without needing special treatment. Around 1 out of every 6 people who gets COVID-19 becomes seriously ill and develops difficulty breathing. Older people, and those with underlying medical problems like high blood pressure, heart problems or diabetes, are more likely to develop serious illness. People with fever, cough and difficulty breathing should seek medical attention.",
                           style: Theme.of(context)
                               .textTheme
-                              .body1
+                              .bodyText2
                               .copyWith(fontSize: 16.0),
                         ),
                       ],

--- a/lib/Widgets/chart.dart
+++ b/lib/Widgets/chart.dart
@@ -31,7 +31,7 @@ class PieChart2State extends State {
         color: Colors.white,
         child: Column(
           children: <Widget>[
-            Text('Covid 19 Reports', style: Theme.of(context).textTheme.title,),
+            Text('Covid 19 Reports', style: Theme.of(context).textTheme.headline6,),
             Row(
               children: <Widget>[
                 const SizedBox(

--- a/lib/Widgets/details.dart
+++ b/lib/Widgets/details.dart
@@ -75,7 +75,7 @@ Widget createDetailItem({BuildContext context, int value, Color color , String t
                 '$value',
                 style: Theme.of(context)
                     .textTheme
-                    .headline
+                    .headline5
                     .copyWith(fontWeight: FontWeight.bold),
               ),
               Padding(

--- a/lib/Widgets/homeNavItems.dart
+++ b/lib/Widgets/homeNavItems.dart
@@ -91,7 +91,7 @@ Widget getHomePageNavItems(
               title,
               style: Theme.of(context)
                   .textTheme
-                  .title
+                  .headline6
                   .copyWith(color: Colors.white),
             ),
             SizedBox(

--- a/lib/Widgets/indicator.dart
+++ b/lib/Widgets/indicator.dart
@@ -44,7 +44,7 @@ class Indicator extends StatelessWidget {
             ),
             Text(
               '${percentage.toStringAsFixed(2)}%',
-              style: Theme.of(context).textTheme.subhead.copyWith(
+              style: Theme.of(context).textTheme.subtitle1.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
             ),

--- a/lib/Widgets/requirements.dart
+++ b/lib/Widgets/requirements.dart
@@ -29,7 +29,7 @@ Widget getRequirementItems({BuildContext context, String text, String imgSrc, Co
       SizedBox(
         height: 8.0,
       ),
-      Text(text, style: Theme.of(context).textTheme.subtitle,)
+      Text(text, style: Theme.of(context).textTheme.subtitle2,)
     ],
   );
 }

--- a/lib/Widgets/symptomsItems.dart
+++ b/lib/Widgets/symptomsItems.dart
@@ -65,7 +65,7 @@ Widget getSymptomsItems(BuildContext context, String text) {
       title: Text(
         text,
         style:
-            Theme.of(context).textTheme.subhead.copyWith(color: Colors.white),
+            Theme.of(context).textTheme.subtitle1.copyWith(color: Colors.white),
       ),
       trailing: Icon(
         Icons.chrome_reader_mode,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: fl_chart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5"
+    version: "0.8.7"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -279,7 +279,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-  fl_chart: ^0.8.5
+  cupertino_icons: ^0.1.3
+  fl_chart: ^0.8.7
   intl: ^0.16.1
   http: ^0.12.0+4
   google_fonts: ^0.3.10


### PR DESCRIPTION
The following usages were depreciated and were replaced suitably. It does not affect what is rendered on the screen. The new usages keeps the code safe for future users.

    Theme.of(context).textTheme.title => Theme.of(context).textTheme.headline6
    Theme.of(context).textTheme.subhead => Theme.of(context).textTheme.subtitle1
    Theme.of(context).textTheme.body1 => Theme.of(context).textTheme.bodyText2
    Theme.of(context).textTheme.headline => Theme.of(context).textTheme.headline5

The following dependencies were updated in pubspec.yaml

    cupertino_icons: ^0.1.2 => ^0.1.3
    fl_chart: ^0.8.6 => ^0.8.7
